### PR TITLE
Keeping tags' attributes

### DIFF
--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -84,7 +84,9 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
           idx = t.interval.end
           t
         }
-        new NonTerminal(n.label, children)
+        // Keep track of the tag's attributes as a Map[String, String]
+        val attributes = n.attributes.map(b => (b.key -> b.value.text)).toMap
+        new NonTerminal(n.label, children, attributes)
     }
     val newRoot = preprocessor(root)
     val paperTitle = mkTree((newRoot \\ "article-title").head, 0)
@@ -92,7 +94,7 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
     // sometimes the body is missing
     val paperBodyOption = (newRoot \\ "body").headOption.map(mkTree(_, paperAbstract.interval.end))
     val children = List(paperTitle, paperAbstract) ::: paperBodyOption.map(List(_)).getOrElse(Nil)
-    new NonTerminal("doc", children)
+    new NonTerminal("doc", children, Map())
   }
 
   val standoff: Tree = mkStandoff()
@@ -111,4 +113,3 @@ case class Author(surname: String, givenNames: String)
 case class Figure(id: String, label: String, caption: String)
 
 case class Table(id: String, label: String, caption: String, xhtml: Node)
-

--- a/src/main/scala/ai/lum/nxmlreader/standoff/Tree.scala
+++ b/src/main/scala/ai/lum/nxmlreader/standoff/Tree.scala
@@ -12,6 +12,7 @@ sealed trait Tree {
   def text: String
   def interval: Interval
   def children: List[Tree]
+  def attributes: Map[String, String]
   def copy(): Tree
   def getTerminals(i: Interval): List[Terminal]
 
@@ -43,7 +44,8 @@ sealed trait Tree {
 
 class NonTerminal(
     val label: String,
-    val children: List[Tree]
+    val children: List[Tree],
+    val attributes: Map[String, String]
 ) extends Tree {
 
   require(children.nonEmpty, "children list is empty")
@@ -56,7 +58,7 @@ class NonTerminal(
 
   def text: String = children.map(_.text).mkString
 
-  def copy(): Tree = new NonTerminal(label, children.map(_.copy()))
+  def copy(): Tree = new NonTerminal(label, children.map(_.copy()), attributes)
 
   def getTerminals(i: Interval): List[Terminal] = {
     if (i intersects interval) {
@@ -78,6 +80,7 @@ class Terminal(
 ) extends Tree {
 
   val children: List[Tree] = Nil
+  val attributes: Map[String, String] = Map()
 
   def copy(): Tree = new Terminal(label, text, interval)
 


### PR DESCRIPTION
Extends the Tree data structure to hold the attributes of a tag,
represented as a non-terminal node in the standoff tree as a
NonTerminal, in a map.

This can be used to retrieve the normalized name of a section like
“materials|methods” which could be useful (i.e. for context)
