### PR TITLE
In text citations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,17 @@ organization := "ai.lum"
 
 scalaVersion := "2.11.8"
 
-scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation")
+scalacOptions ++= Seq(
+  "-feature",
+  "-unchecked",
+  "-deprecation",
+  "-Xlint",
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code",
+  // "-Ywarn-value-discard",
+  "-Ywarn-unused",
+  "-encoding", "utf8"
+)
 
 libraryDependencies ++= Seq(
   "ai.lum" %% "common" % "0.0.7",

--- a/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
@@ -58,11 +58,26 @@ case class NXMLPreprocessor(
     // remove some sections
     case e: Elem if sectionsToIgnore.contains(e.label) | attr(e, "sec-type", sectionsToIgnore) => Nil
 
-    // surround replacements with spaces
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "bibr") => Text(" " + NXMLPreprocessor.BIBR + " ")
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "fig") => Text(" " + NXMLPreprocessor.FIG + " ")
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "table") => Text(" " + NXMLPreprocessor.TABLE + " ")
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "supplementary-material") => Text(" " + NXMLPreprocessor.SUPPL + " ")
+    // retain xref
+    case e: Elem if e.label == "xref" && attr(e, "ref-type", "bibr") =>
+      val e2 = transformChildren(e)
+      val txt = Text(transformText(e2.text))
+      <xref-bibr>{txt}</xref-bibr>
+
+    case e: Elem if e.label == "xref" && attr(e, "ref-type", "fig") =>
+      val e2 = transformChildren(e)
+      val txt = Text(transformText(e2.text))
+      <xref-fig>{txt}</xref-fig>
+
+    case e: Elem if e.label == "xref" && attr(e, "ref-type", "table") =>
+      val e2 = transformChildren(e)
+      val txt = Text(transformText(e2.text))
+      <xref-table>{txt}</xref-table>
+
+    case e: Elem if e.label == "xref" && attr(e, "ref-type", "supplementary-material") =>
+      val e2 = transformChildren(e)
+      val txt = Text(transformText(e2.text))
+      <xref-supplementary>{txt}</xref-supplementary>
 
     // recurse
     case e: Elem => transformChildren(e)

--- a/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
@@ -1,10 +1,23 @@
 package ai.lum.nxmlreader
 
-import scala.xml.{Elem, Node, Text}
+import scala.util.matching.Regex
+import scala.util.matching.Regex.Match
+import scala.xml.{ Elem, Node, Text }
 import scala.xml.transform.RewriteRule
 
 
 trait Preprocessor extends RewriteRule
+
+object PreprocessorUtils {
+
+  // We have a problem with media, in which the XML parser barfs on the inclusion of a newline
+  def preParseHook(text: String): String = {
+    def replaceNewlines(m: Match): String = m.matched.replaceAllLiterally("\n", " ")
+    val mediaFix = new Regex("<media>.*?</media>")
+    mediaFix.replaceAllIn(text, m => replaceNewlines(m))
+  }
+
+}
 
 case class NXMLPreprocessor(
   sectionsToIgnore: Set[String],

--- a/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
@@ -45,8 +45,10 @@ case class NXMLPreprocessor(
     // append newlines to paragraphs
     case e: Elem if e.label == "p" =>
       val e2 = transformChildren(e)
-      val txt = Text(s"${transformText(e2.text)}\n\n")
-      <p>{txt}</p>
+      // FIXME make sure you call transformText() on the children
+      // val txt = Text(s"${transformText(e2.text)}\n\n")
+      // <p>{txt}</p>
+      e2
 
     // remove floats
     case e: Elem if ignoreFloats && attr(e, "position", "float") => Nil
@@ -58,26 +60,7 @@ case class NXMLPreprocessor(
     // remove some sections
     case e: Elem if sectionsToIgnore.contains(e.label) | attr(e, "sec-type", sectionsToIgnore) => Nil
 
-    // retain xref
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "bibr") =>
-      val e2 = transformChildren(e)
-      val txt = Text(transformText(e2.text))
-      <xref-bibr>{txt}</xref-bibr>
-
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "fig") =>
-      val e2 = transformChildren(e)
-      val txt = Text(transformText(e2.text))
-      <xref-fig>{txt}</xref-fig>
-
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "table") =>
-      val e2 = transformChildren(e)
-      val txt = Text(transformText(e2.text))
-      <xref-table>{txt}</xref-table>
-
-    case e: Elem if e.label == "xref" && attr(e, "ref-type", "supplementary-material") =>
-      val e2 = transformChildren(e)
-      val txt = Text(transformText(e2.text))
-      <xref-supplementary>{txt}</xref-supplementary>
+    case e: Elem if e.label == "xref" => e
 
     // recurse
     case e: Elem => transformChildren(e)
@@ -107,12 +90,4 @@ case class NXMLPreprocessor(
     e.attribute(name).exists(values contains _.text)
   }
 
-}
-
-object NXMLPreprocessor extends Preprocessor {
-  // These are strings serving as substitutions
-  val BIBR = "XREF_BIBR" // replaces a bibliography reference
-  val FIG = "XREF_FIG" // replaces a figure
-  val TABLE = "XREF_TABLE" // replaces a table
-  val SUPPL = "XREF_SUPPLEMENTARY" // replaces a supplementary material section
 }

--- a/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NXMLPreprocessor.scala
@@ -1,23 +1,10 @@
 package ai.lum.nxmlreader
 
-import scala.util.matching.Regex
-import scala.util.matching.Regex.Match
 import scala.xml.{ Elem, Node, Text }
 import scala.xml.transform.RewriteRule
 
 
 trait Preprocessor extends RewriteRule
-
-object PreprocessorUtils {
-
-  // We have a problem with media, in which the XML parser barfs on the inclusion of a newline
-  def preParseHook(text: String): String = {
-    def replaceNewlines(m: Match): String = m.matched.replaceAllLiterally("\n", " ")
-    val mediaFix = new Regex("<media>.*?</media>")
-    mediaFix.replaceAllIn(text, m => replaceNewlines(m))
-  }
-
-}
 
 case class NXMLPreprocessor(
   sectionsToIgnore: Set[String],

--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -85,7 +85,7 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
         val children = n.child.toList.flatMap { c =>
           val t = mkTree(c, idx)
           if (t.isDefined) {
-            idx = t.get.interval.end
+            idx = t.get.characterInterval.end
           }
           t
         }
@@ -99,9 +99,9 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
     val paperTitle = mkTree((newRoot \\ "article-title").head, 0).get
     // some papers don't have an abstract
     // also, mkTree returns an Option, that is why we use flatMap
-    val paperAbstractOption = (newRoot \\ "abstract").headOption.flatMap(mkTree(_, paperTitle.interval.end))
+    val paperAbstractOption = (newRoot \\ "abstract").headOption.flatMap(mkTree(_, paperTitle.characterInterval.end))
     // next start is the end of the abstract if there is one, or the end of the title
-    val nextStart = paperAbstractOption.map(_.interval.end).getOrElse(paperTitle.interval.end)
+    val nextStart = paperAbstractOption.map(_.characterInterval.end).getOrElse(paperTitle.characterInterval.end)
     // sometimes the body is missing
     // sometimes the body is empty, this is handled by mkTree returning None
     val paperBodyOption = (newRoot \\ "body").headOption.flatMap(mkTree(_, nextStart))

--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -74,9 +74,11 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
     def mkTree(node: Node, index: Int): Option[Tree] = node match {
       case n @ Text(string) =>
         Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
-      case n if n.label == "title" | n.label == "p" =>
+      // FIXME: can we let n case handle p?
+      case n if n.label == "title" => // | n.label == "p" =>
         val string = n.text
         Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
+      // FIXME: shouldn't this be a terminal?  Isn't "title" such a case?
       case n if n.child.isEmpty =>
         // if nonterminal has no children, don't make a tree node
         None
@@ -89,6 +91,7 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
           }
           t
         }
+        // FIXME: is this ever triggered (see preceding case)?
         if (children.isEmpty) return None
         // Keep track of the tag's attributes as a Map[String, String]
         val attributes = n.attributes.map(b => (b.key -> b.value.text)).toMap

--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -92,6 +92,17 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
       case n if n.label == "title" =>
         val string = n.text
         Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
+      case n if n.label == "p" && n.child.exists(_.label == "xref") =>
+        val children = n.child.toList.map { c =>
+          val string = c.text
+          val attributes = c.attributes.map(b => b.key -> b.value.text).toMap
+          new Terminal(c.label, string, Interval.ofLength(index, string.length), attributes)
+        }
+        val attributes = n.attributes.map(b => (b.key -> b.value.text)).toMap
+        Some(new NonTerminal(n.label, children, attributes))
+      case n if n.label == "p" =>
+        val string = n.text
+        Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
       case n if n.label == "xref" =>
         val string = n.text
         val attributes = n.attributes.map(b => b.key -> b.value.text).toMap

--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -51,6 +51,10 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
     xhtml = tbl \\ "table"
   } yield Table(id, label.text, getTextFrom(caption.head), xhtml.head)
 
+  def inTextCitations: Seq[Node] = for {
+    citation <- root \\ "xref-bibr"
+  } yield citation
+
   def references: Seq[Reference] = for {
     ref <- root \ "back" \ "ref-list" \ "ref"
     id = ref \@ "id"

--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -70,7 +70,7 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
     else ""
   }
 
-  def mkStandoff(): Tree = {
+  private def mkStandoff(): Tree = {
     def mkTree(node: Node, index: Int): Option[Tree] = node match {
       case n @ Text(string) =>
         Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))

--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -57,9 +57,9 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
     val xrefs = findXrefs(Seq(standoff), Nil)
     xrefs.filter(xref => xref.attributes("ref-type") == "bibr")
   }
-
+  
   @tailrec
-  private def findXrefs(remaining: Seq[Tree], results: Seq[Tree]): Seq[Tree] = remaining match {
+  final def findXrefs(remaining: Seq[Tree], results: Seq[Tree]): Seq[Tree] = remaining match {
     case Seq() => results
     case (n:NonTerminal) +: rest => findXrefs(n.children ++ rest, results)
     case (t:Terminal) +: rest if t.label == "xref" => findXrefs(rest, t +: results)

--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -92,21 +92,14 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
       case n if n.label == "title" =>
         val string = n.text
         Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
-      case n if n.label == "p" && n.child.exists(_.label == "xref") =>
-        val children = n.child.toList.map { c =>
-          val string = c.text
-          val attributes = c.attributes.map(b => b.key -> b.value.text).toMap
-          new Terminal(c.label, string, Interval.ofLength(index, string.length), attributes)
-        }
-        val attributes = n.attributes.map(b => (b.key -> b.value.text)).toMap
-        Some(new NonTerminal(n.label, children, attributes))
-      case n if n.label == "p" =>
-        val string = n.text
-        Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
       case n if n.label == "xref" =>
         val string = n.text
-        val attributes = n.attributes.map(b => b.key -> b.value.text).toMap
-        Some(new Terminal(n.label, string, Interval.ofLength(index, string.length), attributes))
+        if (string.length > 0) {
+          val attributes = n.attributes.map(b => b.key -> b.value.text).toMap
+          Some(new Terminal(n.label, string, Interval.ofLength(index, string.length), attributes))
+        } else {
+          None
+        }
       case n if n.child.isEmpty =>
         // if nonterminal has no children, don't make a tree node
         None

--- a/src/main/scala/ai/lum/nxmlreader/NxmlReader.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlReader.scala
@@ -2,9 +2,6 @@ package ai.lum.nxmlreader
 
 import java.io.{ File, InputStream, Reader }
 
-import scala.xml._
-import scala.xml.transform.RewriteRule
-
 
 class NxmlReader(val preprocessor: Preprocessor) {
   def this(
@@ -13,10 +10,7 @@ class NxmlReader(val preprocessor: Preprocessor) {
       transformText: String => String = identity
   ) = this(new NXMLPreprocessor(sectionsToIgnore, ignoreFloats, transformText))
 
-  def parse(string: String): NxmlDocument = {
-    val preprocessedText = PreprocessorUtils.preParseHook(string)
-    new NxmlDocument(XMLWithoutDTD.loadString(preprocessedText), preprocessor)
-  }
+  def parse(string: String): NxmlDocument = new NxmlDocument(XMLWithoutDTD.loadString(string), preprocessor)
   def read(name: String): NxmlDocument = new NxmlDocument(XMLWithoutDTD.loadFile(name), preprocessor)
   def read(file: File): NxmlDocument = new NxmlDocument(XMLWithoutDTD.loadFile(file), preprocessor)
   def read(inputStream: InputStream): NxmlDocument = new NxmlDocument(XMLWithoutDTD.load(inputStream), preprocessor)

--- a/src/main/scala/ai/lum/nxmlreader/NxmlReader.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlReader.scala
@@ -1,6 +1,7 @@
 package ai.lum.nxmlreader
 
 import java.io.{ File, InputStream, Reader }
+
 import scala.xml._
 import scala.xml.transform.RewriteRule
 
@@ -12,7 +13,10 @@ class NxmlReader(val preprocessor: Preprocessor) {
       transformText: String => String = identity
   ) = this(new NXMLPreprocessor(sectionsToIgnore, ignoreFloats, transformText))
 
-  def parse(string: String): NxmlDocument = new NxmlDocument(XMLWithoutDTD.loadString(string), preprocessor)
+  def parse(string: String): NxmlDocument = {
+    val preprocessedText = PreprocessorUtils.preParseHook(string)
+    new NxmlDocument(XMLWithoutDTD.loadString(preprocessedText), preprocessor)
+  }
   def read(name: String): NxmlDocument = new NxmlDocument(XMLWithoutDTD.loadFile(name), preprocessor)
   def read(file: File): NxmlDocument = new NxmlDocument(XMLWithoutDTD.loadFile(file), preprocessor)
   def read(inputStream: InputStream): NxmlDocument = new NxmlDocument(XMLWithoutDTD.load(inputStream), preprocessor)

--- a/src/main/scala/ai/lum/nxmlreader/standoff/Tree.scala
+++ b/src/main/scala/ai/lum/nxmlreader/standoff/Tree.scala
@@ -76,11 +76,11 @@ class NonTerminal(
 class Terminal(
     val label: String,
     val text: String,
-    val characterInterval: Interval
+    val characterInterval: Interval,
+    val attributes: Map[String, String] = Map.empty
 ) extends Tree {
 
   val children: List[Tree] = Nil
-  val attributes: Map[String, String] = Map()
 
   def copy(): Tree = new Terminal(label, text, characterInterval)
 

--- a/src/main/scala/ai/lum/nxmlreader/standoff/Tree.scala
+++ b/src/main/scala/ai/lum/nxmlreader/standoff/Tree.scala
@@ -10,7 +10,7 @@ sealed trait Tree {
 
   def label: String
   def text: String
-  def interval: Interval
+  def characterInterval: Interval
   def children: List[Tree]
   def attributes: Map[String, String]
   def copy(): Tree
@@ -25,7 +25,7 @@ sealed trait Tree {
   }
 
   def getTerminals(): List[Terminal] = {
-    getTerminals(interval)
+    getTerminals(characterInterval)
   }
 
   def root: Tree = parent match {
@@ -54,14 +54,14 @@ class NonTerminal(
   // set children's parent to self
   children.foreach(_._parent = Some(this))
 
-  val interval: Interval = Interval.union(children.map(_.interval))
+  val characterInterval: Interval = Interval.union(children.map(_.characterInterval))
 
   def text: String = children.map(_.text).mkString
 
   def copy(): Tree = new NonTerminal(label, children.map(_.copy()), attributes)
 
   def getTerminals(i: Interval): List[Terminal] = {
-    if (i intersects interval) {
+    if (i intersects characterInterval) {
       for {
         c <- children
         t <- c.getTerminals(i)
@@ -76,16 +76,16 @@ class NonTerminal(
 class Terminal(
     val label: String,
     val text: String,
-    val interval: Interval
+    val characterInterval: Interval
 ) extends Tree {
 
   val children: List[Tree] = Nil
   val attributes: Map[String, String] = Map()
 
-  def copy(): Tree = new Terminal(label, text, interval)
+  def copy(): Tree = new Terminal(label, text, characterInterval)
 
   def getTerminals(i: Interval): List[Terminal] = {
-    if (i intersects interval) List(this) else Nil
+    if (i intersects characterInterval) List(this) else Nil
   }
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.10-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
These changes retain `xref` data in the parse `nxml`.  Seems to work without error for a sample of 10K OA papers from PubMed.

`NxmlDocument` has two new methods:

- `.findXrefs()` for retrieving all `xref` nodes from the standoff.
- `inTextCitations()` for retrieving `xref` `bibr` in-text citations from the standoff.