### PR TITLE
Stop ignoring sub/super scripts

### DIFF
--- a/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
+++ b/src/main/scala/ai/lum/nxmlreader/NxmlDocument.scala
@@ -111,12 +111,14 @@ class NxmlDocument(val root: Node, val preprocessor: Preprocessor) {
     def mkTree(node: Node, index: Int): Option[Tree] = node match {
       case n @ Text(string) =>
         Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
+      case n:Atom[String] =>
+        Some(new Terminal(n.label, n.data, Interval.ofLength(index, n.data.length)))
       case n if n.label == "title" =>
         val string = n.text
         Some(new Terminal(n.label, string, Interval.ofLength(index, string.length)))
       case n if n.label == "xref" =>
         val string = n.text
-        if (string.length > 0) {
+        if (string.nonEmpty) {
           val attributes = n.attributes.map(b => b.key -> b.value.text).toMap
           Some(new Terminal(n.label, string, Interval.ofLength(index, string.length), attributes))
         } else {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.5-SNAPSHOT"
+version in ThisBuild := "0.1.6-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.6-SNAPSHOT"
+version in ThisBuild := "0.1.5-SNAPSHOT"


### PR DESCRIPTION
By adding a new case on `mkStandoff` to handle `Atom[String]` instances, which are equivalent to `Text` instances.

Bumped up the minor version number to reflect the change